### PR TITLE
Refine legislator data loading via contract views

### DIFF
--- a/test/e2e-deployment.test.js
+++ b/test/e2e-deployment.test.js
@@ -60,9 +60,9 @@ describe("Complete End-to-End Deployment Verification", function() {
     // Test with frontend ABI
     const frontendAbi = [
       "function isLegislator(address) view returns (bool)",
-      "function isArea(bytes32) view returns (bool)", 
       "function budget(uint16, bytes32) view returns (uint256 cap, uint256 minted)",
-      "function totalSupplyArea(bytes32) view returns (uint256)"
+      "function getAreas() view returns (bytes32[])",
+      "function getBudgetYears() view returns (uint16[])"
     ];
     
     const frontendContract = new ethers.Contract(contractAddress, frontendAbi, owner);
@@ -122,25 +122,9 @@ describe("Complete End-to-End Deployment Verification", function() {
     // 8. SIMULATE AREA DISCOVERY (like frontend does)
     console.log("\n🔍 STEP 7: Simulating Frontend Area Discovery");
     
-    const topicAdded = dinheiroCarimbado.interface.getEvent("AreaAdded").topicHash;
-    const filter = {
-      address: contractAddress,
-      fromBlock: 0,
-      toBlock: "latest",
-      topics: [topicAdded]
-    };
-    
-    const logs = await ethers.provider.getLogs(filter);
-    const discoveredAreas = logs.map(log => {
-      const parsed = dinheiroCarimbado.interface.parseLog({
-        topics: log.topics,
-        data: log.data
-      });
-      return parsed.args.area;
-    });
-    
+    const discoveredAreas = await dinheiroCarimbado.getAreas();
     expect(discoveredAreas).to.have.lengthOf(2);
-    console.log(`✅ Discovered ${discoveredAreas.length} areas via events`);
+    console.log(`✅ Discovered ${discoveredAreas.length} areas via view function`);
 
     // 9. TEST ACTUAL WORKFLOW
     console.log("\n💸 STEP 8: Testing Full Workflow");

--- a/test/simple-deployment.test.js
+++ b/test/simple-deployment.test.js
@@ -159,41 +159,8 @@ describe("Simple Deployment Verification", function() {
       // Remove one area
       await dinheiroCarimbado.removeArea(educacao);
       
-      // Simulate frontend area discovery
-      const topicAdded = dinheiroCarimbado.interface.getEvent("AreaAdded").topicHash;
-      const topicRemoved = dinheiroCarimbado.interface.getEvent("AreaRemoved").topicHash;
-      
-      const filter = {
-        address: contractAddress,
-        fromBlock: 0,
-        toBlock: "latest",
-        topics: [[topicAdded, topicRemoved]]
-      };
-      
-      const logs = await ethers.provider.getLogs(filter);
-      const areas = new Map();
-      
-      for (const log of logs) {
-        try {
-          const parsed = dinheiroCarimbado.interface.parseLog({
-            topics: log.topics,
-            data: log.data
-          });
-          const area = parsed.args.area;
-          if (parsed.name === "AreaAdded") {
-            areas.set(area, true);
-          } else if (parsed.name === "AreaRemoved") {
-            areas.set(area, false);
-          }
-        } catch (error) {
-          // Ignore parsing errors
-        }
-      }
-      
-      const activeAreas = [...areas.entries()]
-        .filter(([, active]) => active)
-        .map(([area]) => area);
-      
+      const activeAreas = await dinheiroCarimbado.getAreas();
+
       // Should only have SAUDE (EDUCACAO was removed)
       expect(activeAreas).to.have.lengthOf(1);
       expect(activeAreas[0]).to.equal(saude);


### PR DESCRIPTION
## Summary
- add tracking arrays and view helpers in `DinheiroCarimbado` to list areas and retrieve yearly budget snapshots without scanning events
- refactor the legislator frontend script to consume the new helpers when rendering areas and budgets
- update automated tests to exercise the new contract calls instead of fetching historical logs

## Testing
- `npm test` *(fails: Hardhat could not download the Solidity compiler because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c3fe3ab48333ae918698befed349